### PR TITLE
fix: dotfilesLink.sh の shebang を zsh に変更

### DIFF
--- a/dotfilesLink.sh
+++ b/dotfilesLink.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/zsh
 
 # files=(.bashrc .bash_profile .gitignore .gitconfig .gitignore_global .vimrc .spacemacs .tmux.conf .zshrc .scripts)
 files=(.gitconfig .gitignore_global .vimrc .spacemacs .tmux.conf .zshrc .config/ghostty/config)


### PR DESCRIPTION
## 課題

`dotfilesLink.sh` を実行すると、末尾の `source ~/.zshrc` で以下のようなエラーが多数出力されていた。

```
bindkey: command not found
autoload: command not found
${+EPOCHSECONDS} : bad substitution
typeset: -g: invalid option
zsh/system: division by 0
```

## 原因

shebang が `#!/bin/sh`(POSIX shell)であるにもかかわらず、末尾で zsh 専用構文を含む `.zshrc` を source しているため、`bindkey` / `autoload` / `${+VAR}` / `typeset -g` などが解釈できずエラーになっていた。

シンボリックリンク作成処理自体は POSIX 準拠のため成功していたが、この dotfiles はそもそも zsh 前提(`.zshrc` をリンクし ghostty も zsh 起動)であり、shebang が `sh` なのは不整合だった。

## 変更

- shebang を `#!/bin/sh` → `#!/bin/zsh` に変更

## 検証

- `zsh ./dotfilesLink.sh` を実行し、全シンボリックリンクが作成され exit 0 で正常終了することを確認(エラー出力なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)